### PR TITLE
fix: Stop using relative url, specify my url

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
       }
     </style>
     <link rel="manifest" href="/manifest.json" />
-    <link rel="canonical" href="." />
+    <link rel="canonical" href="https://jackhowa.com"/>
     <link rel="apple-touch-icon" href="/images/apple-touch-icon.png" />
     <link
       rel="icon"


### PR DESCRIPTION
this doesn't say anything about relative urls "." https://web.dev/canonical/?utm_source=lighthouse&utm_medium=devtools

before: 

<img width="882" alt="Screen Shot 2020-12-27 at 20 58 12" src="https://user-images.githubusercontent.com/5950956/103179659-1cbe8e80-4886-11eb-979f-c70eeccf9710.png">

after (testing locally lol): 

- got a wrong domain but specifying the correct one :)