### PR TITLE
Remove odd h3, fix formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,10 @@
       content="Jack Howard is a full-stack software engineer in Chicago. He has more than three years experience in React and React Native, JavaScript, and web development. Jack has developed mobile and web apps for journalism organizations, banks and private equity companies, and startups in the transportation industry. He currently works at The Washington Post."
     />
     <meta name="theme-color" content="#ffcfb8" />
-    <meta name="google-site-verification" content="Ufu6ARR8Anx86xdNZ39V76Bnp0_zo5lwVgAWNTLlmbQ" />
+    <meta
+      name="google-site-verification"
+      content="Ufu6ARR8Anx86xdNZ39V76Bnp0_zo5lwVgAWNTLlmbQ"
+    />
     <style>
       html,
       body {
@@ -55,12 +58,6 @@
       h2 {
         padding-top: 0.5em;
         font-size: 2vmax;
-        margin: 0;
-      }
-
-      h3 {
-        padding-top: 0em;
-        font-size: 1.5vmax;
         margin: 0;
       }
 
@@ -114,17 +111,13 @@
           font-size: 3vmax;
         }
 
-        h3 {
-          font-size: 2vmax;
-        }
-
         a {
           font-size: 3vmax;
         }
       }
     </style>
     <link rel="manifest" href="/manifest.json" />
-    <link rel="canonical" href="https://jackhowa.com"/>
+    <link rel="canonical" href="https://jackhowa.com" />
     <link rel="apple-touch-icon" href="/images/apple-touch-icon.png" />
     <link
       rel="icon"
@@ -147,7 +140,6 @@
       </header>
       <div>
         <h2>Software Engineer at <em>The Washington Post</em></h2>
-        <h3>He makes tea (current favorite: T2's Black Rose) and web apps.<h3>
       </div>
       <div id="hr-container">
         <hr />


### PR DESCRIPTION
- inaccessible h3 tag 

before 

<img width="961" alt="Screen Shot 2020-12-27 at 21 02 10" src="https://user-images.githubusercontent.com/5950956/103179745-006f2180-4887-11eb-97d3-afd7b9c84afd.png">

after (removed h3), no related accessible issues

<img width="938" alt="Screen Shot 2020-12-27 at 21 05 30" src="https://user-images.githubusercontent.com/5950956/103179768-314f5680-4887-11eb-9fd7-b8ad66abf5fc.png">


- side effect is a lot less personality lol
- could probably hide this on mobile but want to get a better layout 