### PR TITLE
feat: Simplify hover state dark and light mode logic

### DIFF
--- a/_includes/styles.css
+++ b/_includes/styles.css
@@ -1,19 +1,18 @@
 :root {
   --primary-color: #113134;
-  --primary-color-darker: #0d2426;
   --secondary-color: #ffcfb8;
-  --secondary-color-highlight: #ffffea;
   --text-color: #ffffff;
   --secondary-text-color: #000000;
+  --hover-brightness: 1.1;
 }
 
 @media (prefers-color-scheme: light) {
   :root {
     --primary-color: #ffcfb8;
     --secondary-color: #113134;
-    --secondary-color-highlight: #0d2426;
     --text-color: #000000;
     --secondary-text-color: #ffffff;
+    --hover-brightness: 0.8;
   }
 }
 
@@ -22,7 +21,7 @@ html {
   background-color: var(--primary-color);
   text-align: center;
   position: fixed;
-  width: 100%;
+  width: 100%; 
   height: 100%;
   margin: 0;
   padding: 0;
@@ -75,6 +74,5 @@ a {
 }
 
 a:hover {
-  background-color: var(--secondary-color-highlight);
-  border: 1px solid var(--secondary-color-highlight);
+  filter: brightness(var(--hover-brightness));
 }


### PR DESCRIPTION
- Use hover brightness positive (1.1) and negative (less than 1) filter for hover state

like it better and less-hardcoded

before 

<img width="1312" alt="Screen Shot 2021-10-30 at 12 25 59 PM" src="https://user-images.githubusercontent.com/5950956/139543061-500135a8-5049-4128-b04a-1d985be0f7da.png">

after


<img width="1335" alt="Screen Shot 2021-10-30 at 12 26 04 PM" src="https://user-images.githubusercontent.com/5950956/139543123-1fd42a0d-a2c9-4700-a5a8-09eea2c9622e.png">



before 
<img width="431" alt="Screen Shot 2021-10-30 at 12 27 48 PM" src="https://user-images.githubusercontent.com/5950956/139543143-74197622-5b69-47bd-8c7b-29ec9859c77f.png">



after 

<img width="1239" alt="Screen Shot 2021-10-30 at 12 27 54 PM" src="https://user-images.githubusercontent.com/5950956/139543092-520df3aa-973a-4117-8880-92f34b4bd2db.png">

