### PR TITLE
fix: Use non-color designator on hover for link

### DIFF
--- a/_includes/styles.css
+++ b/_includes/styles.css
@@ -67,3 +67,8 @@ a {
   border-radius: 980px;
   border: 5px solid var(--secondary-color);
 }
+
+a:hover, a:focus {
+  font-weight: bold;
+  border-style: dashed;
+}


### PR DESCRIPTION
Via https://webaim.org/techniques/hypertext/link_text