### PR TITLE
fix: Ensure theme color for dark mode

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -22,6 +22,7 @@ secondLinkTitle: LinkedIn
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/>
     <meta name="description" content="{{metaDescription}}"/>
+    <meta name="theme-color" content="#113134" media="(prefers-color-scheme: dark)">
     <meta name="google-site-verification" content="{{googleSiteVerification}}"/>
     <meta name="generator" content="eleventy">
     {% set css %}


### PR DESCRIPTION
- Weird behavior of showing the light mode on mobile and the black menu bar on desktop on safari. Light mode still working as expected with salmon background