### PR TITLE
feat: Try to get the website to look like the nikes

### DIFF
--- a/_includes/styles.css
+++ b/_includes/styles.css
@@ -74,9 +74,5 @@ a {
 .link-inner-container {
   padding: 0.75rem;
   border-radius: 980px;
-  border: 1px solid transparent;
-}
-
-.link-inner-container:hover, .link-inner-container:focus {
   border: 1px solid var(--yellow);
 }

--- a/_includes/styles.css
+++ b/_includes/styles.css
@@ -3,10 +3,10 @@
   color-scheme: light dark;
   --light-color: white;
   --dark-color: black;
-  /* --pink: #ed3d8e;
+  --pink: rgba(255,102,153,1);
   --yellow: #FFFF00;
   --orange: #FF5733;
-  --red: #f11e1c; */
+  --red: #f11e1c;
 }
 
 html {
@@ -59,20 +59,24 @@ h2 {
 }
 
 a {
-  padding: 1rem;
   font-size: 3vmax;
+  padding: 0.25rem;
 
   /* setting text color of links to match other canvastext */
-  color: var(--canvastext);
+  color: black;
   text-align: center;
   margin: 1rem 0;
   /* seems to cause the border I want via apple */
   border-radius: 980px;
-  background: linear-gradient(90deg, rgba(255,102,153,1) 0%, rgba(241,30,28,1) 50%, rgba(239,116,71,1) 100%);
+  background-color: var(--pink);
 }
 
-a:hover, a:focus {
-  /* border: 2px solid var(--yellow); */
-  /* font-weight: bold; */
-  /* border-style: dashed; */
+.link-inner-container {
+  padding: 0.75rem;
+  border-radius: 980px;
+  border: 1px solid transparent;
+}
+
+.link-inner-container:hover, .link-inner-container:focus {
+  border: 1px solid var(--yellow);
 }

--- a/_includes/styles.css
+++ b/_includes/styles.css
@@ -1,8 +1,12 @@
 :root {
   /* setting color scheme for light/dark text */
   color-scheme: light dark;
-  --light-color: #ffcfb8;
-  --dark-color: #113134;
+  --light-color: white;
+  --dark-color: black;
+  /* --pink: #ed3d8e;
+  --yellow: #FFFF00;
+  --orange: #FF5733;
+  --red: #f11e1c; */
 }
 
 html {
@@ -17,8 +21,7 @@ html {
   margin: 0;
   padding: 0;
   /* system specific font */
-  font-family: -apple-system, system-ui, "Helvetica Neue", "Helvetica", "Arial",
-  sans-serif;
+  font-family: 'Open Sans', sans-serif;
 }
 
 @media (prefers-color-scheme: light) {
@@ -65,10 +68,11 @@ a {
   margin: 1rem 0;
   /* seems to cause the border I want via apple */
   border-radius: 980px;
-  border: 5px solid var(--secondary-color);
+  background: linear-gradient(90deg, rgba(255,102,153,1) 0%, rgba(241,30,28,1) 50%, rgba(239,116,71,1) 100%);
 }
 
 a:hover, a:focus {
-  font-weight: bold;
-  border-style: dashed;
+  /* border: 2px solid var(--yellow); */
+  /* font-weight: bold; */
+  /* border-style: dashed; */
 }

--- a/index.njk
+++ b/index.njk
@@ -27,7 +27,7 @@ secondLinkTitle: LinkedIn
     <meta name="generator" content="eleventy">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@800&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@600;800&display=swap" rel="stylesheet">
     {% set css %}
     {% include "styles.css" %}
     {% endset %}
@@ -46,8 +46,8 @@ secondLinkTitle: LinkedIn
     <main>
       <h1>{{contentTitle}}</h1>
       <h2>{{contentSubtitle}}</h2>
-      <a href="{{firstLinkURL}}" target="_blank" rel="noreferrer">{{firstLinkTitle}}</a>
-      <a href="{{secondLinkURL}}" target="_blank" rel="noreferrer">{{secondLinkTitle}}</a>
+      <a href="{{firstLinkURL}}" target="_blank" rel="noreferrer"><div class="link-inner-container">{{firstLinkTitle}}</div></a>
+      <a href="{{secondLinkURL}}" target="_blank" rel="noreferrer"><div class="link-inner-container">{{secondLinkTitle}}</div></a>
     </main>
   </body>
 

--- a/index.njk
+++ b/index.njk
@@ -25,6 +25,9 @@ secondLinkTitle: LinkedIn
     <meta name="theme-color" content="#113134" media="(prefers-color-scheme: dark)">
     <meta name="google-site-verification" content="{{googleSiteVerification}}"/>
     <meta name="generator" content="eleventy">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@800&display=swap" rel="stylesheet">
     {% set css %}
     {% include "styles.css" %}
     {% endset %}


### PR DESCRIPTION
![IMG_7388](https://user-images.githubusercontent.com/5950956/197408920-e576939b-0583-4033-9a89-931b9a3f4f92.jpeg)
![IMG_7389](https://user-images.githubusercontent.com/5950956/197408923-510fc45e-ceda-426d-ba4c-a5cf70fa7b55.jpeg)

- couldn't get the yellow inset on the border
- went with the gradient. surprisingly difficult to take pictures of colors you want for colors that look good on digital https://sneakernews.com/2021/07/01/nike-rawdacious-tokyo-olympics-2021/ 

<img width="1225" alt="Screen Shot 2022-10-23 at 13 15 08" src="https://user-images.githubusercontent.com/5950956/197408939-b2e99bdc-f1ae-4db8-b3ef-01cd3ec0e9f5.png">
<img width="1218" alt="Screen Shot 2022-10-23 at 13 14 54" src="https://user-images.githubusercontent.com/5950956/197408943-f9302c54-b479-4811-ac6e-a066b71239f7.png">

