### PR TITLE
fix: Ignore content scale per edge warning

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -20,7 +20,7 @@ secondLinkTitle: LinkedIn
 
   <head>
     <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/>
+    <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <meta name="description" content="{{metaDescription}}"/>
     <meta name="theme-color" content="#113134" media="(prefers-color-scheme: dark)">
     <meta name="google-site-verification" content="{{googleSiteVerification}}"/>


### PR DESCRIPTION
via https://github.com/JackHowa/JackHowa.github.io/issues/47

before 

- warning using content size, interesting 

after 

- no warning
<img width="1371" alt="Screenshot 2022-10-28 at 12 26 44 PM" src="https://user-images.githubusercontent.com/5950956/198697445-0af92c36-a486-4642-b61e-879cd85e8a85.png">
